### PR TITLE
retry: add predicate option (currently only function)

### DIFF
--- a/lib/retry.js
+++ b/lib/retry.js
@@ -19,8 +19,12 @@ class Retry extends AigleProxy {
         this._handler = opts;
         break;
       case 'object':
-        const { interval, times } = opts;
+        const { interval, times, predicate } = opts;
         this._times = times || DEFAULT_RETRY;
+        this._predicate = predicate;
+        if (this._predicate && typeof this._predicate !== 'function') {
+          throw new Error('predicate needs to be a function');
+        }
         this._interval =
           typeof interval === 'function' ? interval : interval ? () => interval : undefined;
         this._iterate = this._iterate.bind(this);
@@ -41,7 +45,7 @@ class Retry extends AigleProxy {
   }
 
   _callReject(reason) {
-    if (++this._count === this._times) {
+    if ((this._predicate && !this._predicate(reason)) || ++this._count === this._times) {
       this._promise._reject(reason);
     } else if (this._interval !== undefined) {
       setTimeout(this._iterate, this._interval(this._count));

--- a/typings/aigle-base.d.ts
+++ b/typings/aigle-base.d.ts
@@ -3147,6 +3147,7 @@ declare namespace Aigle {
   export interface RetryOpts {
     times?: number;
     interval?: number | ((count?: number) => number);
+    predicate?: (error?: any) => boolean;
   }
 
   export class Disposer<T> {}

--- a/typings/aigle.d.ts
+++ b/typings/aigle.d.ts
@@ -4587,6 +4587,7 @@ declare namespace Aigle {
   export interface RetryOpts {
     times?: number;
     interval?: number | ((count?: number) => number);
+    predicate?: (error?: any) => boolean;
   }
 
   export class Disposer<T> {}


### PR DESCRIPTION
Predicate function is executed with rejection value, if the call returns
a truthy value then the handler is retried, otherwise the promise is
rejected with the original rejection value